### PR TITLE
Updated project to have a separate -jar.jar file as specified in the que...

### DIFF
--- a/27894707/build.gradle
+++ b/27894707/build.gradle
@@ -13,13 +13,27 @@ dependencies {
 
 jar {
     from sourceSets.main.output
-    from sourceSets.main.allJava
 }
 
+task jarWithSources(type: Jar) {
+	from sourceSets.main.output
+	if (gradle.startParameter.taskNames.any{it == "publishToMavenLocal"}) {
+		from sourceSets.main.allJava
+	}
+}
+
+// Define how maven-publish publishes to the nexus repository
 publishing {
     publications {
         mavenJava(MavenPublication) {
             from components.java
+        }
+        // publish the <project> jar as a standalone artifact
+        mavenJar(MavenPublication) {
+            artifact jarWithSources
+	    //from components.java -- can't have both the above line and this
+            artifactId "${jar.baseName}_jar"
+            version project.version
         }
     }
 }


### PR DESCRIPTION
...stion http://stackoverflow.com/questions/27894707/gradle-publishing-jar-with-source-files-and-dependencies-in-pom.  The .jar only contains classes and it's pom contains the dependencies.  The -jar.jar contains classes and source as required, however the pom doesn't contain the dependencies.  To get the dependencies you need to have the 'from components.java' which is in there but commented out as you can't have this and the 'artifact jarWithSources'.